### PR TITLE
feat: implement init command with fork support for development workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,21 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
-# Binaries for programs and plugins
+# Cloned repositories (managed separately)
+/ui/
+/core/
+
+# Binary builds
+/bin/
+/dist/
+orchcli
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
+
+# Go
+vendor/
+go.work
+go.work.sum
 
 # Test binary, built with `go test -c`
 *.test
@@ -16,21 +25,29 @@
 coverage.*
 *.coverprofile
 profile.cov
+coverage.html
+coverage.txt
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Node
+node_modules/
+npm/binaries/
 
-# Go workspace file
-go.work
-go.work.sum
-
-# env file
+# Environment
 .env
+.env.local
 
-# Editor/IDE
-# .idea/
-# .vscode/
+# OS
+.DS_Store
+Thumbs.db
 
-/ui/
-/core/
-orchcli
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Temporary files
+*.tmp
+*.bak
+*.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,246 @@
-# cli
-CLI for autosetup with manual config for init and deployment
+# OrchCLI - KubeOrchestra Developer CLI
+
+[![Apache 2.0 License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Cloud Native](https://img.shields.io/badge/Cloud%20Native-orange.svg)](https://landscape.cncf.io/)
+
+OrchCLI is the official command-line tool for developing with the KubeOrchestra platform. It streamlines local development, testing, and contribution workflows.
+
+## Features
+
+- 🚀 **Quick Setup**: Clone and configure UI/Core repositories with a single command
+- 🔥 **Hot Reload**: Development environment with automatic code reloading
+- 🍴 **Fork Support**: Seamless workflow for external contributors
+- 📦 **Production Testing**: Test latest production images locally
+- 🐳 **Docker Integration**: Automated container orchestration
+
+## Installation
+
+### Via Go
+```bash
+go install github.com/kubeorchestra/cli@latest
+```
+
+### Via npm (coming soon)
+```bash
+npm install -g @kubeorchestra/orchcli
+```
+
+### From Source
+```bash
+git clone https://github.com/kubeorchestra/cli
+cd cli
+make install
+```
+
+## Quick Start
+
+### Production Testing (No Repos Cloned)
+```bash
+# Initialize for production testing only
+orchcli init
+
+# Run with latest Docker images
+orchcli run
+
+# Run specific version
+orchcli run --version=1.2.3
+```
+
+### Development Setup
+
+#### For Team Members
+```bash
+# Clone official repositories for development
+orchcli init --fork-ui --fork-core
+
+# Or clone only what you need
+orchcli init --fork-ui     # Frontend development only
+orchcli init --fork-core   # Backend development only
+
+# Start development environment
+orchcli dev start
+
+# Make changes and commit directly
+cd ui
+git add .
+git commit -m "feat: add new feature"
+git push origin main
+```
+
+#### For External Contributors
+```bash
+# Fork repos on GitHub first, then:
+orchcli init --fork-ui=youruser/ui --fork-core=youruser/core
+
+# Or work on specific parts:
+orchcli init --fork-ui=youruser/ui    # Frontend only
+orchcli init --fork-core=youruser/core # Backend only
+
+# Start development
+orchcli dev start
+
+# Create PR from your fork
+cd ui
+git checkout -b feature/my-feature
+git push origin feature/my-feature
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `orchcli init` | Initialize environment (production or development) |
+| `orchcli dev start` | Start development environment |
+| `orchcli dev stop` | Stop all services |
+| `orchcli dev logs` | View service logs |
+| `orchcli run` | Run production images |
+| `orchcli update` | Pull latest changes |
+| `orchcli status` | Check environment status |
+
+### Init Command Flags
+
+- **No flags** - Production setup (uses Docker images only, no repos cloned)
+- `--fork-ui` - Clone official UI repo (KubeOrchestra/ui) for team members
+- `--fork-ui=user/repo` - Clone UI from specified fork for external contributors
+- `--fork-core` - Clone official Core repo (KubeOrchestra/core) for team members
+- `--fork-core=user/repo` - Clone Core from specified fork for external contributors
+- `--skip-deps` - Skip dependency installation
+
+### Dev Command Flags
+
+- `--ui-only` - Run only UI locally (Core as container)
+- `--core-only` - Run only Core locally (UI as container)
+
+### Run Command Flags
+
+- `--version=x.y.z` - Specify version for production images
+
+## Project Structure
+
+```
+cli/
+├── cmd/                 # CLI commands
+│   ├── root.go         # Root command
+│   ├── init.go         # Repository initialization
+│   ├── dev.go          # Development commands
+│   └── run.go          # Production testing
+├── docker/             # Docker orchestration files
+│   ├── docker-compose.dev.yml
+│   └── docker-compose.prod.yml
+├── npm/                # npm package distribution
+├── scripts/            # Helper scripts
+└── docs/               # Documentation
+```
+
+## Development
+
+### Building
+```bash
+# Build for current platform
+make build
+
+# Build for all platforms
+make build-all
+
+# Build with specific version
+make build VERSION=1.0.0
+```
+
+### Testing
+```bash
+# Run tests
+make test
+
+# Format code
+make fmt
+
+# Run linters
+make vet
+```
+
+## Architecture
+
+OrchCLI supports two distinct workflows:
+
+### Production Testing Workflow
+- **No repositories cloned** - Uses Docker images exclusively
+- **Quick testing** - Test latest or specific versions
+- **Minimal setup** - Only requires Docker
+
+### Development Workflow
+- **Selective cloning** - Clone only the repos you need (UI, Core, or both)
+- **Fork support** - Automatic upstream configuration for contributors
+- **Hot reload** - Changes reflect immediately during development
+- **Flexible modes** - Work on frontend, backend, or full-stack
+
+Key features:
+1. **Repository Management**: Intelligent cloning with fork detection
+2. **Docker Orchestration**: Seamless container management
+3. **Dependency Handling**: Automatic npm/go module installation
+4. **Git Integration**: Proper remote setup for forks
+
+The CLI owns all orchestration files while UI/Core repositories remain focused on application code.
+
+## Contributing
+
+We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
+
+### For External Contributors
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'feat: add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## Requirements
+
+- Docker & Docker Compose
+- Git
+- Go 1.21+ (for Core development)
+- Node.js 18+ (for UI development)
+
+## Docker Image Tagging Strategy
+
+When publishing Docker images to GitHub Container Registry (ghcr.io):
+
+### Image Names
+- `ghcr.io/kubeorchestra/ui` - Frontend application
+- `ghcr.io/kubeorchestra/core` - Backend application
+
+### Tagging Convention
+- `latest` - Latest stable release
+- `v1.2.3` - Semantic version tags for releases
+- `dev` - Latest development build from main branch
+- `pr-123` - Pull request builds for testing
+- `sha-abc1234` - Commit-specific builds
+
+### Examples
+```bash
+# Run latest stable
+orchcli run
+
+# Run specific version
+orchcli run --version=v1.2.3
+
+# Run development version
+orchcli run --version=dev
+```
+
+## License
+
+Apache-2.0 - see [LICENSE](LICENSE) file for details.
+
+## Support
+
+- 📖 [Documentation](https://github.com/kubeorchestra/cli/docs)
+- 🐛 [Issue Tracker](https://github.com/kubeorchestra/cli/issues)
+- 💬 [Discussions](https://github.com/kubeorchestra/cli/discussions)
+
+## Maintainers
+
+Maintained by the KubeOrchestra team.
+
+---
+
+Made with ❤️ by the KubeOrchestra community

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,334 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	forkUI   string
+	forkCore string
+	skipDeps bool
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize KubeOrchestra development environment",
+	Long: `Initialize the KubeOrchestra environment. 
+
+Without flags: Sets up for production testing using Docker images (no repos cloned).
+With --fork-ui or --fork-core: Clones repositories for development.
+
+Examples:
+  # Production setup (uses Docker images only)
+  orchcli init
+  
+  # Clone official repos for development (internal team members)
+  orchcli init --fork-ui= --fork-core=
+  
+  # Clone from your forks (external contributors)
+  orchcli init --fork-ui=myuser/ui --fork-core=myuser/core
+  
+  # Clone only UI for frontend development
+  orchcli init --fork-ui=
+  
+  # Clone only Core for backend development
+  orchcli init --fork-core=`,
+	RunE: runInit,
+}
+
+func init() {
+	initCmd.Flags().StringVar(&forkUI, "fork-ui", "", "Clone UI repository (use --fork-ui= for official, or --fork-ui=username/repo for fork)")
+	initCmd.Flags().StringVar(&forkCore, "fork-core", "", "Clone Core repository (use --fork-core= for official, or --fork-core=username/repo for fork)")
+	initCmd.Flags().BoolVar(&skipDeps, "skip-deps", false, "Skip dependency installation")
+	
+	// NoOptDefVal allows --fork-ui without value to default to official repo
+	initCmd.Flags().Lookup("fork-ui").NoOptDefVal = "KubeOrchestra/ui"
+	initCmd.Flags().Lookup("fork-core").NoOptDefVal = "KubeOrchestra/core"
+	
+	rootCmd.AddCommand(initCmd)
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	uiSet := cmd.Flags().Changed("fork-ui")
+	coreSet := cmd.Flags().Changed("fork-core")
+	
+	if !uiSet && !coreSet {
+		return setupProduction()
+	}
+	
+	return setupDevelopment(uiSet, coreSet)
+}
+
+func setupProduction() error {
+	fmt.Println("🚀 Setting up OrchCLI for production testing")
+	fmt.Println("   No repositories will be cloned.")
+	fmt.Println("   Docker images will be used for both UI and Core.")
+	
+	if err := checkDocker(); err != nil {
+		return fmt.Errorf("Docker check failed: %w", err)
+	}
+	
+	dirs := []string{"docker", "scripts"}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+	
+	fmt.Println("\n✅ Production environment ready!")
+	fmt.Println("\n📝 Image tags that will be used:")
+	fmt.Println("   - ghcr.io/kubeorchestra/ui:latest")
+	fmt.Println("   - ghcr.io/kubeorchestra/core:latest")
+	fmt.Println("\n   You can specify versions with: orchcli run --version=v1.2.3")
+	fmt.Println("   Run 'orchcli run' to start services with latest images")
+	return nil
+}
+
+func setupDevelopment(cloneUI, cloneCore bool) error {
+	fmt.Println("🔧 Setting up OrchCLI for development")
+	
+	if cloneUI && forkUI == "" {
+		forkUI = "KubeOrchestra/ui"
+	}
+	if cloneCore && forkCore == "" {
+		forkCore = "KubeOrchestra/core"
+	}
+	
+	if err := checkPrerequisites(cloneUI, cloneCore); err != nil {
+		return err
+	}
+	
+	if cloneUI {
+		repoURL, isFork := determineRepoURL(forkUI, "KubeOrchestra/ui")
+		fmt.Printf("📦 Cloning UI repository from %s...\n", repoURL)
+		
+		if err := cloneRepo(repoURL, "./ui"); err != nil {
+			return fmt.Errorf("failed to clone UI repository: %w", err)
+		}
+		
+		if isFork {
+			fmt.Println("🔗 Setting up upstream for UI fork...")
+			if err := setupUpstream("./ui", "https://github.com/KubeOrchestra/ui"); err != nil {
+				return fmt.Errorf("failed to setup upstream for UI: %w", err)
+			}
+		}
+		
+		if !skipDeps {
+			fmt.Println("📥 Installing UI dependencies...")
+			if err := installUIDependencies(); err != nil {
+				fmt.Printf("⚠️  Warning: Failed to install UI dependencies: %v\n", err)
+				fmt.Println("   You can install them manually with: cd ui && npm install")
+			}
+		}
+	}
+	
+	if cloneCore {
+		repoURL, isFork := determineRepoURL(forkCore, "KubeOrchestra/core")
+		fmt.Printf("📦 Cloning Core repository from %s...\n", repoURL)
+		
+		if err := cloneRepo(repoURL, "./core"); err != nil {
+			return fmt.Errorf("failed to clone Core repository: %w", err)
+		}
+		
+		if isFork {
+			fmt.Println("🔗 Setting up upstream for Core fork...")
+			if err := setupUpstream("./core", "https://github.com/KubeOrchestra/core"); err != nil {
+				return fmt.Errorf("failed to setup upstream for Core: %w", err)
+			}
+		}
+		
+		if !skipDeps {
+			fmt.Println("📥 Downloading Core dependencies...")
+			if err := installCoreDependencies(); err != nil {
+				fmt.Printf("⚠️  Warning: Failed to download Core dependencies: %v\n", err)
+				fmt.Println("   You can download them manually with: cd core && go mod download")
+			}
+		}
+	}
+	
+	fmt.Println("\n✅ Development environment ready!")
+	fmt.Println("\n📝 Next steps:")
+	
+	if cloneUI && cloneCore {
+		fmt.Println("   1. Run 'orchcli dev start' to start both UI and Core locally")
+	} else if cloneUI {
+		fmt.Println("   1. Run 'orchcli dev start --ui-only' to start UI locally with Core from Docker")
+	} else if cloneCore {
+		fmt.Println("   1. Run 'orchcli dev start --core-only' to start Core locally with UI from Docker")
+	}
+	
+	fmt.Println("   2. Make your changes in the cloned repositories")
+	fmt.Println("   3. Changes will hot-reload automatically")
+	
+	usingForks := (forkUI != "" && forkUI != "KubeOrchestra/ui") || 
+	              (forkCore != "" && forkCore != "KubeOrchestra/core")
+	
+	if usingForks {
+		fmt.Println("\n🍴 Fork workflow detected (External Contributor):")
+		fmt.Println("   1. Create a feature branch: git checkout -b feature/my-feature")
+		fmt.Println("   2. Push to your fork: git push origin feature/my-feature")
+		fmt.Println("   3. Create a pull request on GitHub")
+	} else if cloneUI || cloneCore {
+		fmt.Println("\n👥 Official repo workflow (Team Member):")
+		fmt.Println("   1. Create a feature branch or work on main")
+		fmt.Println("   2. Push directly: git push origin <branch>")
+	}
+	
+	return nil
+}
+
+func determineRepoURL(repoName, defaultRepo string) (string, bool) {
+	repoName = strings.TrimSpace(repoName)
+	
+	if repoName == defaultRepo || repoName == "" {
+		return fmt.Sprintf("https://github.com/%s", defaultRepo), false
+	}
+	
+	return fmt.Sprintf("https://github.com/%s", repoName), true
+}
+
+func validateRepoFormat(repo string) error {
+	if repo == "" || repo == "KubeOrchestra/ui" || repo == "KubeOrchestra/core" {
+		return nil
+	}
+	
+	pattern := `^[a-zA-Z0-9]([a-zA-Z0-9-]{0,38}[a-zA-Z0-9])?/[a-zA-Z0-9]([a-zA-Z0-9-_.]{0,99}[a-zA-Z0-9])?$`
+	matched, err := regexp.MatchString(pattern, repo)
+	if err != nil {
+		return err
+	}
+	if !matched {
+		return fmt.Errorf("invalid repository format: %s (expected: username/repo)", repo)
+	}
+	return nil
+}
+
+func checkPrerequisites(checkUI, checkCore bool) error {
+	if err := checkCommand("git", "--version"); err != nil {
+		return fmt.Errorf("git is not installed. Please install git first")
+	}
+	
+	if err := checkDocker(); err != nil {
+		return fmt.Errorf("Docker check failed: %w", err)
+	}
+	
+	if checkUI {
+		if err := validateRepoFormat(forkUI); err != nil {
+			return fmt.Errorf("invalid UI repository: %w", err)
+		}
+	}
+	
+	if checkCore {
+		if err := validateRepoFormat(forkCore); err != nil {
+			return fmt.Errorf("invalid Core repository: %w", err)
+		}
+	}
+	
+	if checkUI && dirExists("./ui") {
+		return fmt.Errorf("UI directory already exists. Please remove it first or use 'orchcli update'")
+	}
+	
+	if checkCore && dirExists("./core") {
+		return fmt.Errorf("Core directory already exists. Please remove it first or use 'orchcli update'")
+	}
+	
+	return nil
+}
+
+func checkDocker() error {
+	if err := checkCommand("docker", "--version"); err != nil {
+		return fmt.Errorf("docker is not installed. Please install Docker first")
+	}
+	
+	cmd := exec.Command("docker", "info")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Docker daemon is not running. Please start Docker")
+	}
+	
+	return nil
+}
+
+func checkCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	return cmd.Run()
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return info != nil && info.IsDir()
+}
+
+func cloneRepo(url, path string) error {
+	if dirExists(path) {
+		return fmt.Errorf("directory %s already exists", path)
+	}
+	
+	cmd := exec.Command("git", "clone", url, path)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git clone failed: %w", err)
+	}
+	
+	return nil
+}
+
+func setupUpstream(repoPath, upstreamURL string) error {
+	cmd := exec.Command("git", "remote", "add", "upstream", upstreamURL)
+	cmd.Dir = repoPath
+	
+	if err := cmd.Run(); err != nil {
+		// Check if upstream already exists, update if so
+		checkCmd := exec.Command("git", "remote", "get-url", "upstream")
+		checkCmd.Dir = repoPath
+		if checkErr := checkCmd.Run(); checkErr == nil {
+			updateCmd := exec.Command("git", "remote", "set-url", "upstream", upstreamURL)
+			updateCmd.Dir = repoPath
+			return updateCmd.Run()
+		}
+		return err
+	}
+	
+	fetchCmd := exec.Command("git", "fetch", "upstream")
+	fetchCmd.Dir = repoPath
+	fetchCmd.Stdout = os.Stdout
+	fetchCmd.Stderr = os.Stderr
+	
+	return fetchCmd.Run()
+}
+
+func installUIDependencies() error {
+	if err := checkCommand("npm", "--version"); err != nil {
+		return fmt.Errorf("npm is not installed")
+	}
+	
+	cmd := exec.Command("npm", "install")
+	cmd.Dir = "./ui"
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	
+	return cmd.Run()
+}
+
+func installCoreDependencies() error {
+	if err := checkCommand("go", "version"); err != nil {
+		return fmt.Errorf("go is not installed")
+	}
+	
+	cmd := exec.Command("go", "mod", "download")
+	cmd.Dir = "./core"
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	
+	return cmd.Run()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 )
 
 var (
-	// Version information - set via build flags
 	version   = "dev"
 	commit    = "none"
 	buildDate = "unknown"
@@ -27,7 +26,6 @@ It helps developers:
 	Version: fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, buildDate),
 }
 
-// Execute runs the root command
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -36,12 +34,10 @@ func Execute() {
 }
 
 func init() {
-	// Set custom version template
 	rootCmd.SetVersionTemplate(`OrchCLI {{.Version}}
 {{printf "License: Apache-2.0"}}
 {{printf "Repository: https://github.com/kubeorchestra/cli"}}
 `)
 
-	// Disable completion command by default as we'll add it later with proper implementation
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }


### PR DESCRIPTION
 **What this PR does / why we need it**:

  This PR implements the `orchcli init` command with support for three distinct workflows:

  1. **Production setup** (no flags) - Uses Docker images only, no repositories cloned
  2. **Team member development** (`--fork-ui`/`--fork-core`) - Clones official KubeOrchestra repositories

  3. **External contributor development** (`--fork-ui=user/repo`) - Clones from forks with automatic
  upstream configuration

  Key features:
  - Smart flag parsing using Cobra's NoOptDefVal for optional flag values
  - Automatic fork detection and upstream remote configuration
  - Repository format validation (username/repo)
  - Dependency installation for cloned repos (npm/go)
  - Clear workflow detection with appropriate next steps
  - Docker image tagging strategy documentation

  **Which issue(s) this PR fixes**:
  Fixes #3 , #4, #2 

  **Special notes for your reviewer**:

  The `--fork-ui` and `--fork-core` flags work both with and without values:
  - Without value: clones official repos (team members)
  - With value: clones from specified fork (external contributors)

  This is achieved using Cobra's NoOptDefVal feature to handle optional flag values elegantly.

  **Release note**:
  ```release-note
  NONE
```