### PR TITLE
ci: auto-update scoop bucket on release

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -134,3 +134,53 @@ jobs:
 
       - name: Publish to NPM
         run: npm publish --provenance --access public
+
+  update-scoop-bucket:
+    needs: release-and-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout scoop bucket
+        uses: actions/checkout@v4
+        with:
+          repository: KubeOrch/scoop
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get version and hash
+        id: info
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Download checksums from release
+          curl -sL "https://github.com/KubeOrch/cli/releases/download/v${VERSION}/checksums.txt" -o checksums.txt
+
+          # Extract Windows exe hash
+          HASH=$(grep "orchcli_windows_amd64.exe" checksums.txt | awk '{print $1}')
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION, Hash: $HASH"
+
+      - name: Update scoop manifest
+        run: |
+          VERSION="${{ steps.info.outputs.version }}"
+          HASH="${{ steps.info.outputs.hash }}"
+
+          # Update the JSON using jq
+          jq --arg v "$VERSION" \
+             --arg h "$HASH" \
+             '.version = $v | .architecture."64bit".hash = $h' \
+             bucket/orchcli.json > bucket/orchcli.json.tmp
+
+          mv bucket/orchcli.json.tmp bucket/orchcli.json
+
+          # Show the diff
+          git diff bucket/orchcli.json
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/orchcli.json
+          git commit -m "chore: update to ${{ steps.info.outputs.version }}"
+          git push


### PR DESCRIPTION
## Summary

Adds automation to update the Scoop bucket manifest when a new CLI version is released.

## Changes

- New job `update-scoop-bucket` in release workflow
- Runs after release is published
- Downloads `checksums.txt` from the release
- Extracts SHA256 hash for `orchcli_windows_amd64.exe`
- Updates `KubeOrch/scoop` bucket manifest with:
  - New version number
  - New SHA256 hash
- Commits and pushes to scoop repo

## Benefits

- No more manual Scoop bucket updates
- Version and hash always in sync with releases
- Faster delivery to Scoop users

## Test plan

- [ ] Workflow syntax is valid
- [ ] Next release (v0.0.6+) will auto-update scoop bucket